### PR TITLE
Add option to only update geometries when duplicates are found

### DIFF
--- a/tests/test_parameter_errors.py
+++ b/tests/test_parameter_errors.py
@@ -13,7 +13,7 @@ import processing
 from tests.utils import (get_test_file_copy_path,
                          APPENDED_COUNT,
                          SKIPPED_COUNT,
-                         UPDATED_COUNT)
+                         UPDATED_FEATURE_COUNT)
 
 start_app()
 
@@ -41,7 +41,7 @@ class TestParameterErrors(unittest.TestCase):
 
         self.assertIsNone(res['TARGET_LAYER'])  # The algorithm doesn't run, and doesn't give an output
         self.assertIsNone(res[APPENDED_COUNT])
-        self.assertIsNone(res[UPDATED_COUNT])
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Target layer remains untouched
@@ -63,7 +63,7 @@ class TestParameterErrors(unittest.TestCase):
 
         self.assertIsNone(res['TARGET_LAYER'])  # The algorithm doesn't run, and doesn't give an output
         self.assertIsNone(res[APPENDED_COUNT])
-        self.assertIsNone(res[UPDATED_COUNT])
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Target layer remains untouched
@@ -82,7 +82,7 @@ class TestParameterErrors(unittest.TestCase):
 
         self.assertIsNone(res['TARGET_LAYER'])  # The algorithm doesn't run, and doesn't give an output
         self.assertIsNone(res[APPENDED_COUNT])
-        self.assertIsNone(res[UPDATED_COUNT])
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Target layer remains untouched
@@ -107,7 +107,7 @@ class TestParameterErrors(unittest.TestCase):
 
         self.assertIsNone(res['TARGET_LAYER'])  # The algorithm doesn't run, and doesn't give an output
         self.assertIsNone(res[APPENDED_COUNT])
-        self.assertIsNone(res[UPDATED_COUNT])
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])
         self.assertIsNone(res[SKIPPED_COUNT])
 
         self.assertEqual(layer.featureCount(), 2)

--- a/tests/test_pg_table_pg_table.py
+++ b/tests/test_pg_table_pg_table.py
@@ -17,7 +17,7 @@ from tests.utils import (CommonTests,
                          prepare_pg_db_1,
                          PG_BD_1,
                          APPENDED_COUNT,
-                         UPDATED_COUNT,
+                         UPDATED_FEATURE_COUNT,
                          SKIPPED_COUNT,
                          drop_all_tables,
                          truncate_table)
@@ -93,7 +93,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 4)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 4)
 
         # And counts for update action
@@ -106,7 +106,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 4)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 4)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 4)
         self.assertIsNone(res[SKIPPED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Update
 
     def test_skip_update_m_1(self):
@@ -132,7 +132,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(output_layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 2)
 
         # And counts for update action
@@ -145,7 +145,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(output_layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 1)  # We do 2 updates on a single feature, the count is 1!
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 1)  # We do 2 updates on a single feature, the count is 1!
         self.assertIsNone(res[SKIPPED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Update
 
     def test_skip_different_field_types_can_convert(self):
@@ -176,7 +176,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 1)
 
         # Now test the reverse
@@ -206,7 +206,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 1)
 
     def test_skip_different_field_types_cannot_convert(self):
@@ -232,7 +232,7 @@ class TestPGTablePGTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 0)
 
     @staticmethod

--- a/tests/test_pk.py
+++ b/tests/test_pk.py
@@ -12,7 +12,7 @@ import processing
 
 from tests.utils import (CommonTests,
                          APPENDED_COUNT,
-                         UPDATED_COUNT,
+                         UPDATED_FEATURE_COUNT,
                          SKIPPED_COUNT,
                          get_test_file_copy_path,
                          get_test_path,
@@ -64,7 +64,7 @@ class TestTablePK(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # print([f.name() for f in output_layer.fields()])
@@ -80,7 +80,7 @@ class TestTablePK(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 3)  # Only 1 feature (and 1 attribute in that feature) is actually changed
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 3)  # Only 1 feature (and 1 attribute in that feature) is actually changed
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # print([f.name() for f in output_layer.fields()])
@@ -124,7 +124,7 @@ class TestTablePK(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # print([f.name() for f in pg_layer.fields()])
@@ -140,7 +140,7 @@ class TestTablePK(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 3)  # Only 1 feature (and 1 attribute in that feature) is actually changed
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 3)  # Only 1 feature (and 1 attribute in that feature) is actually changed
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # print([f.name() for f in pg_layer.fields()])
@@ -184,7 +184,7 @@ class TestTablePK(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # print([f.name() for f in pg_layer.fields()])
@@ -200,7 +200,7 @@ class TestTablePK(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 3)  # Only 1 feature (and 1 attribute in that feature) is actually changed
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 3)  # Only 1 feature (and 1 attribute in that feature) is actually changed
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # print([f.name() for f in pg_layer.fields()])

--- a/tests/test_spatial_and_non_spatial.py
+++ b/tests/test_spatial_and_non_spatial.py
@@ -13,7 +13,7 @@ import processing
 
 from tests.utils import (APPENDED_COUNT,
                          SKIPPED_COUNT,
-                         UPDATED_COUNT,
+                         UPDATED_FEATURE_COUNT,
                          CommonTests,
                          get_qgis_gpkg_layer,
                          get_qgis_pg_layer,
@@ -57,7 +57,40 @@ class TestSpatialAndNonSpatialUpdates(unittest.TestCase):
 
         #self.assertEqual(layer.featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertEqual(res[UPDATED_COUNT], 1)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 1)
+        self.assertIsNone(res[SKIPPED_COUNT])
+
+        # Geometry in target layer is not NULL and remained untouched
+        updated_geoms = [f.geometry().asWkt() for f in layer.getFeatures()]
+        for g in original_geoms:
+            self.assertIn(g, updated_geoms)
+
+        # Check that a NULL geometry (QgsGeometry()) has only been the result of the APPEND (1 feature),
+        # while the other 2 features have still a non-NULL geometry
+        self.assertEqual(updated_geoms.count(QgsGeometry().asWkt()), res[APPENDED_COUNT])
+
+    def test_update_geometries_from_non_spatial_layer(self):
+        print('\nINFO: Validating geometries are not updated if source layer is non-spatial...')
+
+        output_layer, layer_path = get_qgis_gpkg_layer('target_multi_polygons')
+        res = self.common._test_copy_selected('source_multi_polygons', output_layer, layer_path)
+        layer = res['TARGET_LAYER']
+        original_geoms = [f.geometry().asWkt() for f in layer.getFeatures()]
+
+        output_path = layer.source().split('|')[0]
+        input_layer_path = "{}|layername={}".format(output_path, 'source_table')
+        input_layer = QgsVectorLayer(input_layer_path, 'layer name', 'ogr')
+
+        res = processing.run("etl_load:appendfeaturestolayer",
+                       {'SOURCE_LAYER': input_layer,
+                        'SOURCE_FIELD': 'name',
+                        'TARGET_LAYER': layer,
+                        'TARGET_FIELD': 'name',
+                        'ACTION_ON_DUPLICATE': 2})  # Update
+
+        #self.assertEqual(layer.featureCount(), 3)
+        self.assertEqual(res[APPENDED_COUNT], 1)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 1)
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Geometry in target layer is not NULL and remained untouched
@@ -90,7 +123,7 @@ class TestSpatialAndNonSpatialUpdates(unittest.TestCase):
 
         #self.assertEqual(layer.featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertEqual(res[UPDATED_COUNT], 1)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 1)
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Geometry in target layer is not NULL and remained untouched

--- a/tests/test_table_table.py
+++ b/tests/test_table_table.py
@@ -13,7 +13,7 @@ import processing
 from tests.utils import (CommonTests,
                          get_qgis_gpkg_layer,
                          APPENDED_COUNT,
-                         UPDATED_COUNT,
+                         UPDATED_FEATURE_COUNT,
                          SKIPPED_COUNT)
 
 start_app()
@@ -89,7 +89,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 4)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 4)
 
         # And counts for update action
@@ -102,7 +102,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 4)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 4)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 4)
         self.assertIsNone(res[SKIPPED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Update
 
     def test_skip_update_m_1(self):
@@ -131,7 +131,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 2)
 
         # And counts for update action
@@ -144,7 +144,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertEqual(res[UPDATED_COUNT], 1)  # We do 2 updates on a single feature, the count is 1!
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 1)  # We do 2 updates on a single feature, the count is 1!
         self.assertIsNone(res[SKIPPED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Update
 
     def test_skip_different_field_types_can_convert(self):
@@ -177,7 +177,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 1)
 
         # Now test the reverse
@@ -207,7 +207,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 1)
 
     def test_skip_different_field_types_cannot_convert(self):
@@ -237,7 +237,7 @@ class TestTableTable(unittest.TestCase):
 
         self.assertEqual(layer.featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 0)
 
     @classmethod

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,7 +18,7 @@ import processing
 from qgis.testing.mocked import get_iface
 
 APPENDED_COUNT = 'APPENDED_COUNT'
-UPDATED_COUNT = 'UPDATED_COUNT'
+UPDATED_FEATURE_COUNT = 'UPDATED_FEATURE_COUNT'
 SKIPPED_COUNT = 'SKIPPED_COUNT'
 
 PG_BD_1 = "db1"
@@ -204,7 +204,7 @@ class CommonTests(unittest.TestCase):
                               'ACTION_ON_DUPLICATE': 0})  # No action
 
         self.assertTrue(output_layer.isValid())
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
         return res
 
@@ -229,7 +229,7 @@ class CommonTests(unittest.TestCase):
                               'TARGET_FIELD': None,
                               'ACTION_ON_DUPLICATE': 0})  # No action
 
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         return res
@@ -256,7 +256,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Let's modify values in the input layer to attempt to update later in the output via our plugin
@@ -276,7 +276,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertEqual(res[UPDATED_COUNT], 2)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 2)
         self.assertIsNone(res[SKIPPED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Update
 
         feature = next(output_layer.getFeatures('"name"=\'abc\''))
@@ -307,7 +307,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Let's modify values in the input layer to be able to check that
@@ -324,7 +324,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 0)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 2)
 
         feature = next(output_layer.getFeatures('"name"=\'abc\''))
@@ -355,7 +355,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Let's modify values in the input layer to be able to check that
@@ -376,7 +376,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 3)
         self.assertEqual(res[APPENDED_COUNT], 1)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 2)
 
         feature = next(output_layer.getFeatures('"name"=\'abc\''))
@@ -406,7 +406,7 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 2)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # These are None because ACTION_ON_DUPLICATE is None
         self.assertIsNone(res[SKIPPED_COUNT])
 
         # Let's modify values in the input layer to make them unmatchable
@@ -423,5 +423,5 @@ class CommonTests(unittest.TestCase):
 
         self.assertEqual(res['TARGET_LAYER'].featureCount(), 4)
         self.assertEqual(res[APPENDED_COUNT], 2)
-        self.assertIsNone(res[UPDATED_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT])  # This is None because ACTION_ON_DUPLICATE is Skip
         self.assertEqual(res[SKIPPED_COUNT], 0)  # Input features not found in target


### PR DESCRIPTION
That is, leaving attributes intact.

Fix #22