### PR TITLE
Load models dynamically, not via copying

### DIFF
--- a/AppendFeaturesToLayer/append_features_to_layer_plugin.py
+++ b/AppendFeaturesToLayer/append_features_to_layer_plugin.py
@@ -79,8 +79,6 @@ class AppendFeaturesToLayerPlugin:
             if not alg.fromFile(filename):
                 print("ERROR: Couldn't load model from {}".format(filename))
                 return
-
-            destFilename = os.path.join(ModelerUtils.modelsFolders()[0], os.path.basename(filename))
-            shutil.copyfile(filename, destFilename)
-
-        QgsApplication.processingRegistry().providerById('model').refreshAlgorithms()
+            alg_added = self.provider.addAlgorithm(alg)
+            if not alg_added:
+                print("ERROR: Couldn't add algorithm from model {}".format(filename))


### PR DESCRIPTION
Fixes https://github.com/gacarrillor/AppendFeaturesToLayer/issues/34

Currently the `.model3` files are copied to the QGIS models directory. This can cause issues if the user cannot write to that directory (e.g. on a network share). Also the files are not removed if the plugin is unloaded or uninstalled.

This PR makes the plugin load the models' algorithms dynamically.



## Before
![Image](https://github.com/user-attachments/assets/6e055820-df2d-4fbd-946d-676b141b528b)

## After
![Image](https://github.com/user-attachments/assets/fc89e46e-9f34-4a64-bba1-931eb6e1e5b7)


edit: I did *not* check if documentation needs updating, the algorithms are all part of the "ETL_LOAD" provider group in the Processing toolbar now. Previously the models stayed under "Models".