### PR TITLE
Allow adding new features including the PK value on update duplicate mode

### DIFF
--- a/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
+++ b/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
@@ -224,7 +224,7 @@ class AppendFeaturesToLayer(QgsProcessingAlgorithm):
 
             if target_idx in target.primaryKeyAttributes():
                 # when the pk is a UUID (or string), we can allways allow updating it
-                if target.dataProvider().name() != 'postgres' or target_field.type() not in [QMetaType.Type.QString, QMetaType.Type.QUuid]:
+                if target_field.type() not in [QMetaType.QString, QMetaType.QUuid]:
                     # We won't update PKs on UPDATE mode, that would be dangerous (at least most of the times)!
                     if action_on_duplicate == self.UPDATE_EXISTING_FEATURE:
                         continue

--- a/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
+++ b/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
@@ -224,7 +224,7 @@ class AppendFeaturesToLayer(QgsProcessingAlgorithm):
 
             if target_idx in target.primaryKeyAttributes():
                 # when the pk is a UUID (or string), we can allways allow updating it
-                if target_field.type() not in [QMetaType.QString, QMetaType.QUuid]:
+                if target.dataProvider().name() != 'postgres' or target_field.type() not in [QMetaType.QString, QMetaType.QUuid]:
                     # We won't update PKs on UPDATE mode, that would be dangerous (at least most of the times)!
                     if action_on_duplicate == self.UPDATE_EXISTING_FEATURE:
                         continue

--- a/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
+++ b/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
@@ -16,7 +16,7 @@
  ***************************************************************************/
 """
 from qgis.PyQt.QtCore import (QVariant,
-                              QCoreApplication)
+                              QCoreApplication, QMetaType)
 
 from qgis.core import (edit,
                        QgsEditError,
@@ -219,16 +219,20 @@ class AppendFeaturesToLayer(QgsProcessingAlgorithm):
         # Define a mapping between source and target layer
         mapping = dict()
         for target_idx in target.fields().allAttributesList():
-            # We won't update PKs on UPDATE mode, that would be dangerous (at least most of the times)!
-            if action_on_duplicate == self.UPDATE_EXISTING_FEATURE and target_idx in target.primaryKeyAttributes():
-                continue
-
-            # Check that we don't have an automatic PK.
-            # Note that for non-automatic PKs, PG is giving a nextval(NULL) as default clause (which should be '').
-            if target.dataProvider().defaultValueClause(target_idx) not in ['', 'nextval(NULL)'] and target_idx in target.primaryKeyAttributes():
-                continue  # We won't be able to update automatic PKs, so skip them
 
             target_field = target.fields().field(target_idx)
+
+            if target_idx in target.primaryKeyAttributes():
+                # when the pk is a UUID (or string), we can allways allow updating it
+                if target_field.type() not in [QMetaType.QString, QMetaType.QUuid]:
+                    # We won't update PKs on UPDATE mode, that would be dangerous (at least most of the times)!
+                    if action_on_duplicate == self.UPDATE_EXISTING_FEATURE:
+                        continue
+
+                    # Check that we don't have an automatic PK.
+                    # Note that for non-automatic PKs, PG is giving a nextval(NULL) as default clause (which should be '').
+                    if target.dataProvider().defaultValueClause(target_idx) not in ['', 'nextval(NULL)']:
+                        continue  # We won't be able to update automatic PKs, so skip them
 
             if target.dataProvider().storageType() == 'GPKG' and target_field.name() == 'fid':
                 continue  # We won't be able to update a GPKG FID, so skip it.

--- a/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
+++ b/AppendFeaturesToLayer/processing/algs/AppendFeaturesToLayer.py
@@ -224,7 +224,7 @@ class AppendFeaturesToLayer(QgsProcessingAlgorithm):
 
             if target_idx in target.primaryKeyAttributes():
                 # when the pk is a UUID (or string), we can allways allow updating it
-                if target.dataProvider().name() != 'postgres' or target_field.type() not in [QMetaType.QString, QMetaType.QUuid]:
+                if target.dataProvider().name() != 'postgres' or target_field.type() not in [QMetaType.Type.QString, QMetaType.Type.QUuid]:
                     # We won't update PKs on UPDATE mode, that would be dangerous (at least most of the times)!
                     if action_on_duplicate == self.UPDATE_EXISTING_FEATURE:
                         continue

--- a/tests/test_pk.py
+++ b/tests/test_pk.py
@@ -6,10 +6,8 @@ from qgis.core import (QgsApplication,
                        QgsFeatureRequest)
 from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
-from urllib3 import request
 
 import processing
-import uuid
 
 from tests.utils import (CommonTests,
                          APPENDED_COUNT,

--- a/tests/test_pk.py
+++ b/tests/test_pk.py
@@ -2,11 +2,14 @@ from qgis.core import (QgsApplication,
                        QgsVectorLayer,
                        QgsProcessingFeatureSourceDefinition,
                        QgsProject,
-                       QgsFeature)
+                       QgsFeature,
+                       QgsFeatureRequest)
 from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
+from urllib3 import request
 
 import processing
+import uuid
 
 from tests.utils import (CommonTests,
                          APPENDED_COUNT,
@@ -207,6 +210,262 @@ class TestTablePK(unittest.TestCase):
 
         # # The only updated value
         self.assertEqual(pg_layer.getFeature(1)["descripcion"], 'Los datos deben corresponder a su modelo')
+
+    def test_append_update_pks_pg_uuid_notnull(self):
+        print('\nINFO: Validating to set/update PKs (UUID, NOT NULL) in PG...')
+
+        # Create empty input layer
+        input_layer = QgsVectorLayer("Point?crs=epsg:3116&field=fid:integer&field=T_Id:string&field=codigo:string&field=descripcion:string", "uuid-layer", "memory")
+        self.assertTrue(input_layer.isValid())
+
+        # Get target layer with UUID PK
+        target_layer = get_qgis_pg_layer(PG_BD_1, 'tipo_regla_uuid', truncate=True)  # T_Id, codigo, descripcion
+        self.assertTrue(target_layer.isValid())
+        self.assertEqual(target_layer.featureCount(), 0)
+
+        QgsProject.instance().addMapLayers([input_layer, target_layer])
+
+        # Create two features on the target. One with and one without a UUID
+        # We pass the uuids to be able to playe with them.
+        f = QgsFeature(target_layer.fields())
+        uuid_1 = '15431753-059f-4c23-ba60-0e0fc0b28fa5'
+        f.setAttribute("T_Id", uuid_1)
+        f.setAttribute("codigo", "R0001")
+        f.setAttribute("descripcion", "ABC")
+        self.assertTrue(target_layer.dataProvider().addFeatures([f]))
+        self.assertEqual(target_layer.featureCount(), 1)
+   
+        f = QgsFeature(target_layer.fields())
+        f.setAttribute("codigo", "R0002")
+        f.setAttribute("descripcion", "DEF")
+        self.assertTrue(target_layer.dataProvider().addFeatures([f]))
+        self.assertEqual(target_layer.featureCount(), 2)
+
+        # get the generated UUID of the second feature
+        uuids_in_target = [f["T_Id"] for f in target_layer.getFeatures()]
+        self.assertEqual(len(uuids_in_target), 2) 
+        uuid_2 = list(set(uuids_in_target) - {uuid_1})[0]
+        self.assertIsNotNone(uuid_2)
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+
+        # Create two features on the input. One with and one without a UUID
+        f = QgsFeature(input_layer.fields())
+        uuid_3 = '12616fa9-f8f8-4746-b5e9-302b387cdb8f'
+        f.setAttribute("T_Id", uuid_3) 
+        f.setAttribute("codigo", "R0003") 
+        f.setAttribute("descripcion", "GHI")
+        self.assertTrue(input_layer.dataProvider().addFeatures([f]))
+
+        f = QgsFeature(input_layer.fields())
+        f.setAttribute("codigo", "R0004") 
+        f.setAttribute("descripcion", "JKL")
+        self.assertTrue(input_layer.dataProvider().addFeatures([f]))
+
+        # Status in the input layer:
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: None, codigo: R0004, descripcion: JKL
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+
+        # Expected is the adding of two features, one with the given and the other with the generated UUID 
+        res = processing.run("etl_load:appendfeaturestolayer",
+                             {'SOURCE_LAYER': input_layer,
+                              'SOURCE_FIELD': None,
+                              'TARGET_LAYER': target_layer,
+                              'TARGET_FIELD': None,
+                              'ACTION_ON_DUPLICATE': 0})  # No action
+
+        self.assertEqual(res['TARGET_LAYER'].featureCount(), 4)
+        self.assertEqual(res[APPENDED_COUNT], 2)
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT]) 
+        self.assertIsNone(res[SKIPPED_COUNT])
+
+        # get the generated UUID of the fourth feature
+        uuids_in_target = [f["T_Id"] for f in target_layer.getFeatures()]
+        self.assertEqual(len(uuids_in_target), 4) 
+        uuid_4 = list(set(uuids_in_target) - {uuid_1, uuid_2, uuid_3})[0]
+        self.assertIsNotNone(uuid_4)
+
+        # Status in the input layer:
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: None, codigo: R0004, descripcion: JKL
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_4, codigo: R0004, descripcion: JKL
+
+        # Now we do it again, and now it creates the two features again, generating two new UUIDs (because caring itself for uniqueness)
+        res = processing.run("etl_load:appendfeaturestolayer",
+                             {'SOURCE_LAYER': input_layer,
+                              'SOURCE_FIELD': None,
+                              'TARGET_LAYER': target_layer,
+                              'TARGET_FIELD': None,
+                              'ACTION_ON_DUPLICATE': 0})  # No action
+
+        self.assertEqual(res['TARGET_LAYER'].featureCount(), 6)
+        self.assertEqual(res[APPENDED_COUNT], 2)
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT]) 
+        self.assertIsNone(res[SKIPPED_COUNT])
+
+        # get the generated UUID of the fifth and the sixth feature
+        uuids_in_target = [f["T_Id"] for f in target_layer.getFeatures()]
+        self.assertEqual(len(uuids_in_target), 6) 
+        uuid_5 = list(set(uuids_in_target) - {uuid_1, uuid_2, uuid_3, uuid_4})[0]
+        self.assertIsNotNone(uuid_5)
+        uuid_6 = list(set(uuids_in_target) - {uuid_1, uuid_2, uuid_3, uuid_4, uuid_5})[0]
+        self.assertIsNotNone(uuid_6)
+
+        # Status in the input layer:
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: None, codigo: R0004, descripcion: JKL
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_4, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_5, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_6, codigo: R0004, descripcion: JKL
+
+        # When we would skip, the one with the existing UUID (uuid_3) will be skipped, but the one with None in the source (R0004)
+        res = processing.run("etl_load:appendfeaturestolayer",
+                             {'SOURCE_LAYER': input_layer,
+                              'SOURCE_FIELD': 'T_Id',
+                              'TARGET_LAYER': target_layer,
+                              'TARGET_FIELD': 'T_Id',
+                              'ACTION_ON_DUPLICATE': 1})  # Skip duplicates
+
+        self.assertEqual(res['TARGET_LAYER'].featureCount(), 7)
+        self.assertEqual(res[APPENDED_COUNT], 1)
+        self.assertIsNone(res[UPDATED_FEATURE_COUNT]) 
+        self.assertEqual(res[SKIPPED_COUNT], 1)
+
+        # get the generated UUID of the fifth feature
+        uuids_in_target = [f["T_Id"] for f in target_layer.getFeatures()]
+        self.assertEqual(len(uuids_in_target), 7) 
+        uuid_7 = list(set(uuids_in_target) - {uuid_1, uuid_2,uuid_3, uuid_4, uuid_5,uuid_6})[0]
+        self.assertIsNotNone(uuid_7)
+
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: None, codigo: R0004, descripcion: JKL
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_4, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_5, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_6, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_7, codigo: R0004, descripcion: JKL
+
+        # let's fix the mess
+        # we remove the feature 4 from the input
+        request = QgsFeatureRequest()
+        request.setFilterExpression(f'"codigo" = \'R0004\'')
+        R0004_feature = list(input_layer.getFeatures(request))[0]
+        input_layer.dataProvider().deleteFeatures([R0004_feature.id()])
+        # we append proper features for 5, 6 and 7 and update them
+        f = QgsFeature(input_layer.fields())
+        f.setAttribute("T_Id", uuid_5) 
+        f.setAttribute("codigo", "R0005") 
+        f.setAttribute("descripcion", "MNO")
+        self.assertTrue(input_layer.dataProvider().addFeatures([f]))
+        f = QgsFeature(input_layer.fields())
+        f.setAttribute("T_Id", uuid_6) 
+        f.setAttribute("codigo", "R0006") 
+        f.setAttribute("descripcion", "PQR")
+        self.assertTrue(input_layer.dataProvider().addFeatures([f]))
+        f = QgsFeature(input_layer.fields())
+        f.setAttribute("T_Id", uuid_7) 
+        f.setAttribute("codigo", "R0007") 
+        f.setAttribute("descripcion", "STU")
+        self.assertTrue(input_layer.dataProvider().addFeatures([f]))
+        
+        # Status in the input layer:
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_5, codigo: R0005, descripcion: MNO
+        # T_Id: uuid_6, codigo: R0006, descripcion: PQR
+        # T_Id: uuid_7, codigo: R0007, descripcion: STU
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_4, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_5, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_6, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_7, codigo: R0004, descripcion: JKL
+
+        # And we perform an update for the duplicate considering the T_Id (UUID)
+        res = processing.run("etl_load:appendfeaturestolayer",
+                             {'SOURCE_LAYER': input_layer,
+                              'SOURCE_FIELD': 'T_Id',
+                              'TARGET_LAYER': target_layer,
+                              'TARGET_FIELD': 'T_Id',
+                              'ACTION_ON_DUPLICATE': 2})  # UPDATE
+
+        self.assertEqual(res['TARGET_LAYER'].featureCount(), 7)
+        self.assertEqual(res[APPENDED_COUNT], 0) # No new appended (all already exist)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 4) # The four others are updated, although one (R0003)without changes
+        self.assertIsNone(res[SKIPPED_COUNT])
+
+        uuids_in_target = [f["T_Id"] for f in target_layer.getFeatures()]
+        self.assertEqual(len(uuids_in_target), 7) 
+        self.assertEqual(set(uuids_in_target), {uuid_1, uuid_2,uuid_3, uuid_4, uuid_5,uuid_6, uuid_7})
+        codigos_in_target = [f["codigo"] for f in target_layer.getFeatures()]
+        self.assertEqual( set(codigos_in_target), {'R0001', 'R0002', 'R0003', 'R0004', 'R0005', 'R0006', 'R0007'})
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_4, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_5, codigo: R0005, descripcion: MNO
+        # T_Id: uuid_6, codigo: R0006, descripcion: PQR
+        # T_Id: uuid_7, codigo: R0007, descripcion: STU
+
+        # Now we add a new one with a new UUID, which should be added without problems
+        f = QgsFeature(input_layer.fields())
+        uuid_8 = 'bae27e96-bffc-4b27-9cdc-162731043293'
+        f.setAttribute("T_Id", uuid_8) 
+        f.setAttribute("codigo", "R0008") 
+        f.setAttribute("descripcion", "VWX")
+        self.assertTrue(input_layer.dataProvider().addFeatures([f]))
+
+        # And we perform an update for the duplicate considering the T_Id (UUID)
+        res = processing.run("etl_load:appendfeaturestolayer",
+                             {'SOURCE_LAYER': input_layer,
+                              'SOURCE_FIELD': 'T_Id',
+                              'TARGET_LAYER': target_layer,
+                              'TARGET_FIELD': 'T_Id',
+                              'ACTION_ON_DUPLICATE': 2})  # UPDATE
+
+        self.assertEqual(res['TARGET_LAYER'].featureCount(), 8)
+        self.assertEqual(res[APPENDED_COUNT], 1)
+        self.assertEqual(res[UPDATED_FEATURE_COUNT], 4) # The four others are updated, although without changes
+        self.assertIsNone(res[SKIPPED_COUNT])
+
+        uuids_in_target = [f["T_Id"] for f in target_layer.getFeatures()]
+        self.assertEqual(len(uuids_in_target), 8) 
+        self.assertEqual(set(uuids_in_target), {uuid_1, uuid_2,uuid_3, uuid_4, uuid_5,uuid_6, uuid_7, uuid_8})
+        codigos_in_target = [f["codigo"] for f in target_layer.getFeatures()]
+        self.assertEqual( set(codigos_in_target), {'R0001', 'R0002', 'R0003', 'R0004', 'R0005', 'R0006', 'R0007', 'R0008'})
+
+        # Status in the target layer:
+        # T_Id: uuid_1, codigo: R0001, descripcion: ABC
+        # T_Id: uuid_2, codigo: R0002, descripcion: DEF
+        # T_Id: uuid_3, codigo: R0003, descripcion: GHI
+        # T_Id: uuid_4, codigo: R0004, descripcion: JKL
+        # T_Id: uuid_5, codigo: R0005, descripcion: MNO
+        # T_Id: uuid_6, codigo: R0006, descripcion: PQR
+        # T_Id: uuid_7, codigo: R0007, descripcion: STU
+        # T_Id: uuid_8, codigo: R0008, descripcion: VWX
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -132,6 +132,10 @@ def prepare_pg_db_1():
 
             CREATE TABLE IF NOT EXISTS tipo_regla_no_serial("T_Id" integer NOT NULL, codigo text, descripcion text);
             ALTER TABLE tipo_regla_no_serial ADD CONSTRAINT pk_tipo_regla_no_serial PRIMARY KEY ("T_Id");
+                    
+            CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+                    
+            CREATE TABLE IF NOT EXISTS tipo_regla_uuid("T_Id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(), codigo text, descripcion text);
         """)
         cur.close()
         conn.commit()
@@ -162,6 +166,8 @@ def drop_all_tables(db=PG_BD_1):
         DROP TABLE tipo_regla;
         ALTER TABLE tipo_regla_no_serial DROP CONSTRAINT IF EXISTS pk_tipo_regla_no_serial;
         DROP TABLE tipo_regla_no_serial;
+        ALTER TABLE tipo_regla_uuid DROP CONSTRAINT IF EXISTS pk_tipo_regla_uuid;
+        DROP TABLE tipo_regla_uuid;
         """)
         cur.close()
         conn.commit()


### PR DESCRIPTION
Especially on synchronizing and migration it's important that the pk is used from external dataset as well.

Means it should not touch the pk on update (as before) but add new ones from the source (although they are automatically generated in the target).

This will not be the case with no-action. With no-action it will just append (with auto-generated pk's in the target).

This PR introduces the change, that on update-duplicate-mode it uses the PK from the source on adding, but on updating an existing one (duplicate) it does not append the PK to the updated attrs.

### Use Case:

I use this algorithm in a model where I import datasets into my main database. The objects in the datasets have IDs (UUIDs), as do the objects in the main database. When I import data, I want existing objects to be updated and new objects to be appended. The new objects should keep the ID from the dataset, meaning they should be inserted with their UUID as the primary key.